### PR TITLE
Fix nop recognizer

### DIFF
--- a/da.go
+++ b/da.go
@@ -43,7 +43,7 @@ func daTypeIa(name string, pc uint, ins uint) string {
 
 func daTypeIb(name string, pc uint, ins uint) string {
 	imm, rs1, rd := decodeIa(ins)
-	if rs1 == 0 && imm == 0 {
+	if rd == 0 && rs1 == 0 && imm == 0 {
 		return fmt.Sprintf("nop")
 	}
 	if rs1 == 0 {


### PR DESCRIPTION
The disassembler should only print `nop` for instructions that also have the zero register as their destination. Otherwise the instruction is actually performing a load of 0, which is not a nop. Example: `00000513` should be `li a0,0`.

Thanks for the great tool!